### PR TITLE
3 feature dry run and force support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ Please read [Contributor Guide](.github/CONTRIBUTING_DOC/CONTRIBUTING.md) for mo
 ## Features
 
 - [x] publish npm package by npm cli, so must install npm cli or under nodejs env
-  - by default docker image `node:20.11.1-alpine` for env of nodejs
-  - if you use `local` backend, must install `npm` and `node` at local
+    - by default docker image `node:20.11.1-alpine` for env of nodejs
+    - if you use `local` backend, must install `npm` and `node` at local
 - [x] flag `npm-registry` to set custom npm registry, and support npm whoami check
 - [x] support `npm-token` or `npm-username` and `npm-password` to publish
 - [x] support `npm-tag` to publish, as `latest`
+    - [x] flag `npm-force-tag` true will check the prefix of the prerelase version by semver, when tag name not `latest`
+      or `next` (v1.1+)
 - [x] support `npm-access` to publish scoped package
 - [x] support `npm-folder` to publish, which must containing `package.json`
+- [x] flag `npm-dry-run` will not publish, but will run `npm pack` to generate tarball (v1.1+)
 - [x] can skip `npm whoami` check by open `npm-skip-whoami`
 - [x] can skip `npm ssl` verify by open `npm-skip-verify-ssl`
 - [x] can fail on version conflict by open `npm-fail-on-version-conflict`

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -31,18 +31,19 @@ woodpecker-npm
 
 ## Settings
 
-| Name           | Required | Default value | Description                                                                                               |
-|----------------|----------|---------------|-----------------------------------------------------------------------------------------------------------|
-| `debug`        | **no**   | *false*       | open debug log or open by env `PLUGIN_DEBUG`                                                              |
-| `npm-registry` | **no**   | *none*        | NPM registry settings if empty will use https://registry.npmjs.org/                                       |
-| `npm-username` | **yes**  | *none*        | NPM username                                                                                              |
-| `npm-password` | **yes**  | *none*        | NPM password                                                                                              |
-| `npm-token`    | **yes**  | *none*        | NPM token to use when publishing packages. if token is set, username and password will be ignored.        |
-| `npm-email`    | **yes**  | *none*        | NPM email                                                                                                 |
-| `npm-folder`   | **no**   | *none*        | folder containing package.json, empty will use workspace                                                  |
-| `npm-dry-run`  | **no**   | *false*       | NPM dry run mode, will not publish to NPM registry (v1.1+)                                                |
-| `npm-tag`      | **no**   | *none*        | NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, experimental, etc. |
-| `npm-access`   | **no**   | *none*        | NPM scoped package access                                                                                 |
+| Name            | Required | Default value | Description                                                                                                                                   |
+|-----------------|----------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `debug`         | **no**   | *false*       | open debug log or open by env `PLUGIN_DEBUG`                                                                                                  |
+| `npm-registry`  | **no**   | *none*        | NPM registry settings if empty will use https://registry.npmjs.org/                                                                           |
+| `npm-username`  | **yes**  | *none*        | NPM username                                                                                                                                  |
+| `npm-password`  | **yes**  | *none*        | NPM password                                                                                                                                  |
+| `npm-token`     | **yes**  | *none*        | NPM token to use when publishing packages. if token is set, username and password will be ignored.                                            |
+| `npm-email`     | **yes**  | *none*        | NPM email                                                                                                                                     |
+| `npm-folder`    | **no**   | *none*        | folder containing package.json, empty will use workspace                                                                                      |
+| `npm-dry-run`   | **no**   | *false*       | NPM dry run mode, will not publish to NPM registry (v1.1+)                                                                                    |
+| `npm-tag`       | **no**   | *none*        | NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, experimental, etc.                                     |
+| `npm-force-tag` | **no**   | *false*       | NPM enable this will check the prefix of the prerelase version by semver, when tag name not `latest` or `next`, open this will force publish. |
+| `npm-access`    | **no**   | *none*        | NPM scoped package access                                                                                                                     |
 
 **custom settings**
 
@@ -165,6 +166,7 @@ steps:
       npm-dry-run: true # dry run mode, will not publish to NPM registry
       ## NPM tag to use when publishing packages. this will cover package.json version field.
       npm-tag: alpha # NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, next, etc.
+      npm-force-tag: true # NPM enable this will check the prefix of the prerelase version by semver, when tag name not `latest` or `next`
       ## NPM scoped package access
       npm-access: foo
       ## folder containing package.json, empty will use workspace

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -40,6 +40,7 @@ woodpecker-npm
 | `npm-token`    | **yes**  | *none*        | NPM token to use when publishing packages. if token is set, username and password will be ignored.        |
 | `npm-email`    | **yes**  | *none*        | NPM email                                                                                                 |
 | `npm-folder`   | **no**   | *none*        | folder containing package.json, empty will use workspace                                                  |
+| `npm-dry-run`  | **no**   | *false*       | NPM dry run mode, will not publish to NPM registry (v1.1+)                                                |
 | `npm-tag`      | **no**   | *none*        | NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, experimental, etc. |
 | `npm-access`   | **no**   | *none*        | NPM scoped package access                                                                                 |
 
@@ -85,6 +86,7 @@ steps:
         from_secret: npm_publish_password
       npm-email: # NPM email
         from_secret: npm_publish_email
+      # npm-dry-run: true # dry run mode, will not publish to NPM registry
       # npm-folder: . # folder containing package.json, empty will use workspace
       # npm-tag: alpha # NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, experimental, etc. do not use latest, next
       ## fail NPM publish if version already exists in NPM registry, most use in tag publish
@@ -124,6 +126,7 @@ steps:
         from_secret: npm_publish_password
       npm-email: # NPM email
         from_secret: npm_publish_email
+      # npm-dry-run: true # dry run mode, will not publish to NPM registry
       # npm-folder: . # folder containing package.json, empty will use workspace
       # npm-tag: alpha # NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, next, etc.
       ## fail NPM publish if version already exists in NPM registry, most use in tag publish
@@ -159,6 +162,7 @@ steps:
       ## NPM email
       npm-email:
         from_secret: npm_publish_email
+      npm-dry-run: true # dry run mode, will not publish to NPM registry
       ## NPM tag to use when publishing packages. this will cover package.json version field.
       npm-tag: alpha # NPM publish option to avoid tag being marked as latest, commonly used are beta, alpha, next, etc.
       ## NPM scoped package access

--- a/plugin_npm/command.go
+++ b/plugin_npm/command.go
@@ -43,5 +43,9 @@ func publishCommand(settings *Settings) *exec.Cmd {
 		commandArgs = append(commandArgs, "--access", settings.ScopedAccess)
 	}
 
+	if settings.NpmDryRun {
+		commandArgs = append(commandArgs, "--dry-run")
+	}
+
 	return exec.Command("npm", commandArgs...)
 }

--- a/plugin_npm/command.go
+++ b/plugin_npm/command.go
@@ -1,6 +1,9 @@
 package plugin_npm
 
-import "os/exec"
+import (
+	"fmt"
+	"os/exec"
+)
 
 // versionCommand gets the npm version
 func versionCommand() *exec.Cmd {
@@ -45,6 +48,26 @@ func publishCommand(settings *Settings) *exec.Cmd {
 
 	if settings.NpmDryRun {
 		commandArgs = append(commandArgs, "--dry-run")
+	}
+
+	return exec.Command("npm", commandArgs...)
+}
+
+// unpublishCommand runs the unpublish command
+func unpublishCommand(settings *Settings, name, version string) *exec.Cmd {
+	commandArgs := []string{"unpublish"}
+
+	if settings.Registry != "" {
+		commandArgs = append(commandArgs, "--registry", settings.Registry)
+	}
+
+	commandArgs = append(commandArgs, fmt.Sprintf("%s@%s", name, version))
+
+	if settings.Tag != "" {
+		commandArgs = append(commandArgs, "--tag", settings.Tag)
+		if settings.TagForceEnable {
+			commandArgs = append(commandArgs, "--force")
+		}
 	}
 
 	return exec.Command("npm", commandArgs...)

--- a/plugin_npm/flag.go
+++ b/plugin_npm/flag.go
@@ -28,6 +28,9 @@ const (
 	CliNameNpmTag = "settings.npm-tag"
 	EnvNameNpmTag = "PLUGIN_NPM_TAG"
 
+	CliNameNpmForceTag = "settings.npm-force-tag"
+	EnvNameNpmForceTag = "PLUGIN_NPM_FORCE_TAG"
+
 	CliNameNpmFolder = "settings.npm-folder"
 	EnvNameNpmFolder = "PLUGIN_NPM_FOLDER"
 
@@ -86,6 +89,13 @@ func GlobalFlag() []cli.Flag {
 			Usage:   "NPM tag to use when publishing packages. this will cover package.json version field.",
 			EnvVars: []string{EnvNameNpmTag},
 		},
+		&cli.BoolFlag{
+			Name:    CliNameNpmForceTag,
+			Usage:   "NPM enable this will check the prefix of the prerelase version by semver, when tag name not `latest` or `next`",
+			Value:   false,
+			EnvVars: []string{EnvNameNpmForceTag},
+		},
+
 		&cli.StringFlag{
 			Name:    CliNameNpmFolder,
 			Usage:   "NPM folder to use when publishing packages which must containing package.json. default will use workspace",
@@ -155,6 +165,7 @@ func BindCliFlags(c *cli.Context,
 		NpmRcUserHomeEnable:   c.Bool(CliNameNpmRCUserHomeEnable),
 		NpmDryRun:             c.Bool(CLiNameNpmDryRun),
 		Tag:                   c.String(CliNameNpmTag),
+		TagForceEnable:        c.Bool(CliNameNpmForceTag),
 		SkipVerifySSL:         c.Bool(CliNameNpmSkipVerifySSL),
 		SkipWhoAmI:            c.Bool(CliNameSkipWhoAmi),
 		FailOnVersionConflict: c.Bool(CliNameFailOnVersionConflict),

--- a/plugin_npm/flag.go
+++ b/plugin_npm/flag.go
@@ -45,6 +45,9 @@ const (
 
 	CliNameNpmRCUserHomeEnable = "settings.npm-rc-user-home-enable"
 	EnvNameNpmRCUserHomeEnable = "PLUGIN_NPM_RC_USER_HOME_ENABLE"
+
+	CLiNameNpmDryRun = "settings.npm-dry-run"
+	EnvNameNpmDryRun = "PLUGIN_NPM_DRY_RUN"
 )
 
 // GlobalFlag
@@ -114,6 +117,11 @@ func GlobalFlag() []cli.Flag {
 			Usage:   fmt.Sprintf("enable .npmrc file write user home, default .npmrc file will write in `%s`", CliNameNpmFolder),
 			EnvVars: []string{EnvNameNpmRCUserHomeEnable},
 		},
+		&cli.BoolFlag{
+			Name:    CLiNameNpmDryRun,
+			Usage:   "dry run mode, will not publish to NPM registry",
+			EnvVars: []string{EnvNameNpmDryRun},
+		},
 	}
 }
 
@@ -145,6 +153,7 @@ func BindCliFlags(c *cli.Context,
 
 		Folder:                c.String(CliNameNpmFolder),
 		NpmRcUserHomeEnable:   c.Bool(CliNameNpmRCUserHomeEnable),
+		NpmDryRun:             c.Bool(CLiNameNpmDryRun),
 		Tag:                   c.String(CliNameNpmTag),
 		SkipVerifySSL:         c.Bool(CliNameNpmSkipVerifySSL),
 		SkipWhoAmI:            c.Bool(CliNameSkipWhoAmi),

--- a/plugin_npm/impl_npm.go
+++ b/plugin_npm/impl_npm.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/Masterminds/semver/v3"
 	"github.com/woodpecker-kit/woodpecker-tools/wd_log"
 	"net"
 	"net/url"
@@ -115,6 +116,24 @@ func (p *NpmPlugin) authenticate() error {
 		return err
 	}
 
+	return nil
+}
+
+// checkPackageVersionBySemver
+func (p *NpmPlugin) checkPackageVersionBySemver() error {
+	// Verify package.json file
+	npm, err := readPackageFile(p.Settings.Folder)
+	if err != nil {
+		return fmt.Errorf("checkPackageVersionBySemver invalid package.json: %v", err)
+	}
+	targetVersion, errNpmVersion := semver.NewVersion(npm.Version)
+	if errNpmVersion != nil {
+		return fmt.Errorf("checkPackageVersionBySemver can not parse version: %s err: %v", npm.Version, errNpmVersion)
+	}
+	prereleaseInfo := targetVersion.Prerelease()
+	if strings.Index(prereleaseInfo, p.Settings.Tag) != 0 {
+		return fmt.Errorf("checkPackageVersionBySemver npm-tag [ %s ] must be the prefix of the prerelase version: [ %s ]", p.Settings.Tag, npm.Version)
+	}
 	return nil
 }
 

--- a/plugin_npm/settings.go
+++ b/plugin_npm/settings.go
@@ -18,6 +18,11 @@ var (
 		wd_info.BuildStatusError,
 		wd_info.BuildStatusKilled,
 	}
+
+	tagForceNotSupport = []string{
+		"latest",
+		"next",
+	}
 )
 
 type (
@@ -38,13 +43,15 @@ type (
 		Token        string
 		ScopedAccess string
 
-		Folder                string
-		NpmRcUserHomeEnable   bool
+		Folder              string
+		Tag                 string
+		TagForceEnable      bool
+		NpmRcUserHomeEnable bool
+
 		NpmDryRun             bool
 		SkipVerifySSL         bool
 		SkipWhoAmI            bool
 		FailOnVersionConflict bool
-		Tag                   string
 	}
 
 	npmPackage struct {

--- a/plugin_npm/settings.go
+++ b/plugin_npm/settings.go
@@ -40,6 +40,7 @@ type (
 
 		Folder                string
 		NpmRcUserHomeEnable   bool
+		NpmDryRun             bool
 		SkipVerifySSL         bool
 		SkipWhoAmI            bool
 		FailOnVersionConflict bool


### PR DESCRIPTION
* flag `npm-force-tag` check package version by semver and force publish ([c854472a](https://github.com/woodpecker-kit/woodpecker-npm/commit/c854472a902c89c336558e52a6b5d10552ec4815)), fe [#3](https://github.com/woodpecker-kit/woodpecker-npm/issues/3)

* flag `npm-dry-run` to open dry run mode, will not publish to NPM registry ([174a43e4](https://github.com/woodpecker-kit/woodpecker-npm/commit/174a43e4d9dd0e9c04a42477bab2774fe5fada11))

* change .npmrc path, default .npmrc file will write in `npm-folder` ([128057bc](https://github.com/woodpecker-kit/woodpecker-npm/commit/128057bcda9759e14d472d5857c17bd0446e0258))
